### PR TITLE
update ava to version 2.1.0 and remove support for Node.js v6/7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 os: linux
 
 node_js:
-  - 6
-  - 8
-  - 10
-  - 11
+  - "8"
+  - "10"
+  - "12"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"homepage": "https://github.com/maxrimue/combijson#readme",
 	"devDependencies": {
-		"ava": "^1.1.0",
+		"ava": "^2.1.0",
 		"xo": "^0.24.0"
 	},
 	"xo": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"concat"
 	],
 	"engines": {
-		"node": ">=6.0.0"
+		"node": ">=8.0.0"
 	},
 	"author": "Max Rittmüller",
 	"license": "ISC",


### PR DESCRIPTION
Closes #22 
